### PR TITLE
Atualização do nome do produto

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -35,7 +35,7 @@ function enter(e, textinput, prefix) {
             <div id="content">
 <br/>
 <h1>{{ self.title()|safe }}</h1>
-<hr/> Tool Labs – Ferramentas para projetos lusófonos <br/><br/>
+<hr/> Wikimedia Toolforge – Ferramentas para projetos lusófonos <br/><br/>
 {% block content %}{{ content }}{% endblock %}
             </div>
        </div>


### PR DESCRIPTION
O antigo "Tool Labs" agora é parte do Wikimedia Cloud Services, e passou a ser chamado de Toolforge.

**Ver também**
* https://phabricator.wikimedia.org/phame/post/view/59/labs_and_tool_labs_being_renamed/
* https://wikitech.wikimedia.org/wiki/Help:Cloud_Services_Introduction#WMCS_products_and_services